### PR TITLE
fixed linking errors during build on raspberry pi

### DIFF
--- a/libsoundio-sys/build.rs
+++ b/libsoundio-sys/build.rs
@@ -106,6 +106,14 @@ fn main() {
     // Link soundio.
     println!("cargo:rustc-link-lib=static=soundio");
 
+    // Actually only necessary on Raspberry Pi
+    // but it doesn't effect build on e.g. Ubuntu.
+    if target.contains("linux") {
+        println!("cargo:rustc-link-lib=asound");
+        println!("cargo:rustc-link-lib=pulse");
+        println!("cargo:rustc-link-lib=jack");
+    }
+
     // OSX
     if target.contains("apple") {
         println!("cargo:rustc-link-lib=framework=AudioToolbox");


### PR DESCRIPTION
I tested this on Raspberry Pi and on another Linux (Ubuntu). Both works fine with this fix. See #2 for discussion.