### PR TITLE
Add feature flags to conditionally compile in backends

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,12 @@ Bindings to libsoundio for audio input and output.
 keywords = ["audio", "media", "soundio"]
 categories = ["multimedia", "multimedia::audio"]
 
+[features]
+pulse_support = ["libsoundio-sys/pulse_support"]
+jack_support = ["libsoundio-sys/jack_support"]
+alsa_support = ["libsoundio-sys/alsa_support"]
+default = ["pulse_support"]
+
 [dependencies]
 libsoundio-sys = { path = "libsoundio-sys", version = "0.3.0" }
 

--- a/libsoundio-sys/Cargo.toml
+++ b/libsoundio-sys/Cargo.toml
@@ -22,3 +22,8 @@ cc = "1.0"
 
 [badges]
 maintenance = { status = "actively-developed" }
+
+[features]
+pulse_support = []
+jack_support = []
+alsa_support = []

--- a/libsoundio-sys/build.rs
+++ b/libsoundio-sys/build.rs
@@ -48,10 +48,35 @@ fn main() {
 
     // Is the target Windows?
     let windows = target.contains("windows");
+    let linux = target.contains("linux");
 
     // Create a new cmake config.
     let mut cfg = cmake::Config::new("libsoundio");
+    cfg.define("ENABLE_JACK", "OFF");
+    cfg.define("ENABLE_ALSA", "OFF");
+    cfg.define("ENABLE_PULSE", "OFF");
 
+    #[cfg(feature = "jack_support")]
+    {
+        cfg.define("ENABLE_JACK", "ON");
+        if linux {
+            println!("cargo:rustc-link-lib=jack");
+        }
+    }
+    #[cfg(feature = "alsa_support")]
+    {
+        cfg.define("ENABLE_ALSA", "ON");
+        if linux {
+            println!("cargo:rustc-link-lib=asound");
+        }
+    }
+    #[cfg(feature = "pulse_support")]
+    {
+        cfg.define("ENABLE_PULSE", "ON");
+        if linux {
+            println!("cargo:rustc-link-lib=pulse");
+        }
+    }
     // When cross-compiling, we're pretty unlikely to find a `dlltool` binary
     // lying around, so try to find another if it exists
     // What is dlltool?


### PR DESCRIPTION
Added some feature flags to optionally compile in the various backends so you don't have to have all of them installed to target one platform.