### PR TITLE
Fix libsoundio-sys looking for libsoundio.a in wrong location

### DIFF
--- a/libsoundio-sys/build.rs
+++ b/libsoundio-sys/build.rs
@@ -92,9 +92,20 @@ fn main() {
         .define("BUILD_TESTS", "OFF")
         .build();
 
+    let static_lib_path = dst.join("build").join("libsoundio.a");
+
+    assert!(
+        static_lib_path.exists(),
+        "{} not found",
+        static_lib_path.display()
+    );
+
     println!(
         "cargo:rustc-link-search=native={}",
-        dst.join("lib").display()
+        static_lib_path
+            .parent()
+            .expect("No parent of static library")
+            .display()
     );
 
     // Windows...


### PR DESCRIPTION
Simple fix, `libsoundio.a` is output in `OUT_DIR/build`, not in `OUT_DIR/lib`.