### PR TITLE
Fix libsoundio-sys looking for libsoundio.a in wrong location

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,10 @@
 [package]
 name = "soundio"
 version = "0.2.1"
-authors = ["Tim Hutt <tdhutt@gmail.com>", "Ramy <RamiHg@users.noreply.github.com>"]
+authors = [
+    "Tim Hutt <tdhutt@gmail.com>",
+    "Ramy <RamiHg@users.noreply.github.com>",
+]
 license = "MIT"
 readme = "README.md"
 repository = "https://github.com/RamiHg/soundio-rs"
@@ -15,6 +18,14 @@ categories = ["multimedia", "multimedia::audio"]
 
 [dependencies]
 libsoundio-sys = { path = "libsoundio-sys", version = "0.3.0" }
+
+[features]
+default = []
+jack = ["libsoundio-sys/jack"]
+pulseaudio = ["libsoundio-sys/pulseaudio"]
+alsa = ["libsoundio-sys/alsa"]
+coreaudio = ["libsoundio-sys/coreaudio"]
+wasapi = ["libsoundio-sys/wasapi"]
 
 # Examples
 

--- a/libsoundio-sys/Cargo.toml
+++ b/libsoundio-sys/Cargo.toml
@@ -2,7 +2,10 @@
 name = "libsoundio-sys"
 edition = "2018"
 version = "0.3.0"
-authors = ["Tim Hutt <tdhutt@gmail.com>", "Ramy <RamiHg@users.noreply.github.com>"]
+authors = [
+    "Tim Hutt <tdhutt@gmail.com>",
+    "Ramy <RamiHg@users.noreply.github.com>",
+]
 links = "soundio"
 build = "build.rs"
 repository = "https://github.com/RamiHg/soundio-rs/libsoundio-sys"
@@ -22,3 +25,11 @@ cc = "1.0"
 
 [badges]
 maintenance = { status = "actively-developed" }
+
+[features]
+default = []
+jack = []
+pulseaudio = []
+alsa = []
+coreaudio = []
+wasapi = []

--- a/libsoundio-sys/build.rs
+++ b/libsoundio-sys/build.rs
@@ -92,9 +92,20 @@ fn main() {
         .define("BUILD_TESTS", "OFF")
         .build();
 
+    let static_lib_path = dst.join("build").join("libsoundio.a");
+
+    assert!(
+        static_lib_path.exists(),
+        "{} not found",
+        static_lib_path.display()
+    );
+
     println!(
         "cargo:rustc-link-search=native={}",
-        dst.join("lib").display()
+        static_lib_path
+            .parent()
+            .expect("No parent of static library")
+            .display()
     );
 
     // Windows...

--- a/libsoundio-sys/build.rs
+++ b/libsoundio-sys/build.rs
@@ -85,12 +85,39 @@ fn main() {
     t!(fs::create_dir_all(env::var("OUT_DIR").unwrap()));
 
     // Don't bother with shared libs.
-    let dst = cfg
+    let mut cfg = cfg
         .define("BUILD_DYNAMIC_LIBS", "OFF")
         .define("BUILD_STATIC_LIBS", "ON")
         .define("BUILD_EXAMPLE_PROGRAMS", "OFF")
-        .define("BUILD_TESTS", "OFF")
-        .build();
+        .define("BUILD_TESTS", "OFF");
+
+    if cfg!(feature = "jack") {
+        cfg = cfg.define("BUILD_JACK", "ON");
+    }
+
+    if cfg!(feature = "pulseaudio") {
+        cfg = cfg.define("BUILD_PULSEAUDIO", "ON");
+        println!("cargo:rustc-link-lib=pulse");
+        println!("cargo:rustc-link-lib=pulse-simple");
+        println!("cargo:rustc-link-lib=pulse-mainloop-glib");
+    }
+
+    if cfg!(feature = "alsa") {
+        cfg = cfg.define("BUILD_ALSA", "ON");
+        println!("cargo:rustc-link-lib=asound");
+    }
+
+    if cfg!(feature = "coreaudio") {
+        cfg = cfg.define("BUILD_COREAUDIO", "ON");
+        // No need to issue link directives here, they are done below.
+    }
+
+    if cfg!(feature = "wasapi") {
+        cfg = cfg.define("BUILD_WASAPI", "ON");
+        // No need to issue link directives here, they are done below.
+    }
+
+    let dst = cfg.build();
 
     let static_lib_path = dst.join("build").join("libsoundio.a");
 
@@ -108,19 +135,22 @@ fn main() {
             .display()
     );
 
+    // Link soundio.
+    println!("cargo:rustc-link-lib=static=soundio");
+
+    // Link pulse
+
     // Windows...
     if target.contains("windows") {
         // We need to link ole32 on Windows.
         println!("cargo:rustc-link-lib=ole32");
-    }
-
-    // Link soundio.
-    println!("cargo:rustc-link-lib=static=soundio");
-
-    // OSX
-    if target.contains("apple") {
+    } else if target.contains("apple") {
         println!("cargo:rustc-link-lib=framework=AudioToolbox");
         println!("cargo:rustc-link-lib=framework=CoreAudio");
         println!("cargo:rustc-link-lib=framework=CoreFoundation");
+    } else {
+        println!("cargo:rustc-link-lib=pulse");
+        println!("cargo:rustc-link-lib=pulse-simple");
+        println!("cargo:rustc-link-lib=pulse-mainloop-glib");
     }
 }


### PR DESCRIPTION
This depends on my earlier PR, this adds build feature gating to allow using this library to properly link against the libraries libsoundio is built against.